### PR TITLE
JUnit 4 implementation. Simplify name helper.

### DIFF
--- a/burst-android/src/main/java/com/squareup/burst/BurstAndroid.java
+++ b/burst-android/src/main/java/com/squareup/burst/BurstAndroid.java
@@ -56,7 +56,7 @@ public class BurstAndroid extends AndroidTestRunner {
         for (Object[] methodArgs : Burst.explodeArguments(method)) {
           // Loop constructor args last so we only iterate and explode each test method once.
           for (Object[] constructorArgs : constructorArgsList) {
-            String name = Burst.explodedName(method.getName(), constructorArgs, methodArgs);
+            String name = nameWithArguments(method.getName(), constructorArgs, methodArgs);
             result.addTest(
                 new BurstTestCase(name, constructor, constructorArgs, method, methodArgs));
           }
@@ -68,5 +68,17 @@ public class BurstAndroid extends AndroidTestRunner {
             "Unknown Test type. Not TestCase or TestSuite. " + test.getClass().getName());
       }
     }
+  }
+
+  private static String nameWithArguments(String name, Object[] constructorArgs,
+      Object[] methodArgs) {
+    StringBuilder builder = new StringBuilder(name);
+    if (constructorArgs.length > 0) {
+      builder.append('[').append(Burst.friendlyName(constructorArgs)).append(']');
+    }
+    if (methodArgs.length > 0) {
+      builder.append('[').append(Burst.friendlyName(methodArgs)).append(']');
+    }
+    return builder.toString();
   }
 }

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
@@ -1,16 +1,49 @@
 package com.squareup.burst;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.List;
+import org.junit.Test;
 import org.junit.runner.Runner;
 import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
 
-public class BurstJUnit4 extends Suite {
+import static java.util.Collections.unmodifiableList;
+
+public final class BurstJUnit4 extends Suite {
   public BurstJUnit4(Class<?> cls) throws InitializationError {
     super(cls, explode(cls));
   }
 
-  static List<Runner> explode(Class<?> cls) {
-    throw new UnsupportedOperationException("Not implemented.");
+  static List<Runner> explode(Class<?> cls) throws InitializationError {
+    TestClass testClass = new TestClass(cls);
+    List<FrameworkMethod> testMethods = testClass.getAnnotatedMethods(Test.class);
+
+    List<FrameworkMethod> burstMethods = new ArrayList<>(testMethods.size());
+    for (FrameworkMethod testMethod : testMethods) {
+      Method method = testMethod.getMethod();
+      for (Object[] methodArgs : Burst.explodeArguments(method)) {
+        burstMethods.add(new BurstMethod(method, methodArgs));
+      }
+    }
+
+    Constructor<?> constructor = Burst.findConstructor(cls);
+    Object[][] constructorArgsList = Burst.explodeArguments(constructor);
+    List<Runner> burstRunners = new ArrayList<>(constructorArgsList.length);
+    for (Object[] constructorArgs : constructorArgsList) {
+      burstRunners.add(new BurstRunner(cls, constructor, constructorArgs, burstMethods));
+    }
+
+    return unmodifiableList(burstRunners);
+  }
+
+  static String nameWithArguments(String name, Object[] arguments) {
+    if (arguments.length == 0) {
+      return name;
+    }
+    return name + '[' + Burst.friendlyName(arguments) + ']';
   }
 }

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
@@ -1,0 +1,33 @@
+package com.squareup.burst;
+
+import java.lang.reflect.Method;
+import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.runners.model.FrameworkMethod;
+
+import static com.squareup.burst.BurstJUnit4.nameWithArguments;
+import static com.squareup.burst.Util.checkNotNull;
+
+final class BurstMethod extends FrameworkMethod {
+  private final Object[] methodArgs;
+
+  BurstMethod(Method method, Object[] methodArgs) {
+    super(checkNotNull(method, "method"));
+    this.methodArgs = checkNotNull(methodArgs, "methodArgs");
+  }
+
+  @Override public Object invokeExplosively(final Object target, Object... params)
+      throws Throwable {
+    checkNotNull(target, "target");
+
+    ReflectiveCallable callable = new ReflectiveCallable() {
+      @Override protected Object runReflectiveCall() throws Throwable {
+        return getMethod().invoke(target, methodArgs);
+      }
+    };
+    return callable.run();
+  }
+
+  @Override public String getName() {
+    return nameWithArguments(super.getName(), methodArgs);
+  }
+}

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
@@ -1,0 +1,51 @@
+package com.squareup.burst;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.util.List;
+import org.junit.runner.Description;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+import static com.squareup.burst.BurstJUnit4.nameWithArguments;
+import static com.squareup.burst.Util.checkNotNull;
+
+final class BurstRunner extends BlockJUnit4ClassRunner {
+  private final Constructor<?> constructor;
+  private final Object[] constructorArgs;
+  private final List<FrameworkMethod> methods;
+
+  BurstRunner(Class<?> cls, Constructor<?> constructor, Object[] constructorArgs,
+      List<FrameworkMethod> methods) throws InitializationError {
+    super(checkNotNull(cls, "cls"));
+    this.constructor = checkNotNull(constructor, "constructor");
+    this.constructorArgs = checkNotNull(constructorArgs, "constructorArgs");
+    this.methods = checkNotNull(methods, "methods");
+  }
+
+  @Override protected List<FrameworkMethod> getChildren() {
+    return methods;
+  }
+
+  @Override protected String getName() {
+    return nameWithArguments(super.getName(), constructorArgs);
+  }
+
+  @Override protected Description describeChild(FrameworkMethod method) {
+    return Description.createTestDescription(getName(), method.getName());
+  }
+
+  @Override protected Object createTest() throws Exception {
+    return constructor.newInstance(constructorArgs);
+  }
+
+  @Override protected void validateConstructor(List<Throwable> errors) {
+    // Constructor was already validated by Burst.
+  }
+
+  @Override protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation,
+      boolean isStatic, List<Throwable> errors) {
+    // Methods were already validated by Burst.
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/BurstJUnit4Test.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/BurstJUnit4Test.java
@@ -1,0 +1,110 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class BurstJUnit4Test {
+  private final JournalingListener listener = new JournalingListener();
+
+  @Test public void constructorNone() throws InitializationError {
+    BurstJUnit4 runner = new BurstJUnit4(ConstructorNoArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.ConstructorNoArgumentTest)",
+        "FINISH testMethod(com.squareup.burst.ConstructorNoArgumentTest)");
+  }
+
+  @Test public void constructorSingle() throws InitializationError {
+    BurstJUnit4 runner = new BurstJUnit4(ConstructorSingleArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.PEPSI])",
+        "FINISH testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.PEPSI])",
+        "START testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.COKE])",
+        "FINISH testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.COKE])",
+        "START testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.RC_COLA])",
+        "FINISH testMethod(com.squareup.burst.ConstructorSingleArgumentTest[Soda.RC_COLA])");
+  }
+
+  @Test public void constructorMultiple() throws InitializationError {
+    BurstJUnit4 runner = new BurstJUnit4(ConstructorMultipleArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.CHIPS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.NUTS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.PEPSI, Snack.CANDY])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.CHIPS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.NUTS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.COKE, Snack.CANDY])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.CHIPS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.NUTS])",
+        "START testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.ConstructorMultipleArgumentTest[Soda.RC_COLA, Snack.CANDY])");
+  }
+
+  @Test public void method() throws InitializationError {
+    BurstJUnit4 runner = new BurstJUnit4(MethodTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START single[Soda.PEPSI](com.squareup.burst.MethodTest)",
+        "FINISH single[Soda.PEPSI](com.squareup.burst.MethodTest)",
+        "START single[Soda.COKE](com.squareup.burst.MethodTest)",
+        "FINISH single[Soda.COKE](com.squareup.burst.MethodTest)",
+        "START single[Soda.RC_COLA](com.squareup.burst.MethodTest)",
+        "FINISH single[Soda.RC_COLA](com.squareup.burst.MethodTest)",
+        "START none(com.squareup.burst.MethodTest)",
+        "FINISH none(com.squareup.burst.MethodTest)",
+        "START multiple[Soda.PEPSI, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.PEPSI, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.PEPSI, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.PEPSI, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.PEPSI, Snack.CANDY](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.PEPSI, Snack.CANDY](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.COKE, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.COKE, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.COKE, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.COKE, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.COKE, Snack.CANDY](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.COKE, Snack.CANDY](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.RC_COLA, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.RC_COLA, Snack.CHIPS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.RC_COLA, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.RC_COLA, Snack.NUTS](com.squareup.burst.MethodTest)",
+        "START multiple[Soda.RC_COLA, Snack.CANDY](com.squareup.burst.MethodTest)",
+        "FINISH multiple[Soda.RC_COLA, Snack.CANDY](com.squareup.burst.MethodTest)");
+  }
+
+  @Test public void constructorAndMethod() throws InitializationError {
+    BurstJUnit4 runner = new BurstJUnit4(ConstructorAndMethodTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "FINISH testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "START testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "FINISH testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "START testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "FINISH testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.PEPSI])",
+        "START testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "FINISH testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "START testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "FINISH testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "START testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "FINISH testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.COKE])",
+        "START testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])",
+        "FINISH testMethod[Snack.CHIPS](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])",
+        "START testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])",
+        "FINISH testMethod[Snack.NUTS](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])",
+        "START testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])",
+        "FINISH testMethod[Snack.CANDY](com.squareup.burst.ConstructorAndMethodTest[Soda.RC_COLA])");
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/ConstructorAndMethodTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ConstructorAndMethodTest.java
@@ -1,0 +1,20 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstJUnit4.class)
+public final class ConstructorAndMethodTest {
+  private final Soda soda;
+
+  public ConstructorAndMethodTest(Soda soda) {
+    this.soda = soda;
+  }
+
+  @Test public void testMethod(Snack snack) {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/ConstructorMultipleArgumentTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ConstructorMultipleArgumentTest.java
@@ -1,0 +1,22 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstJUnit4.class)
+public final class ConstructorMultipleArgumentTest {
+  private final Soda soda;
+  private final Snack snack;
+
+  public ConstructorMultipleArgumentTest(Soda soda, Snack snack) {
+    this.soda = soda;
+    this.snack = snack;
+  }
+
+  @Test public void testMethod() {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/ConstructorNoArgumentTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ConstructorNoArgumentTest.java
@@ -1,0 +1,13 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstJUnit4.class)
+public final class ConstructorNoArgumentTest {
+  @Test public void testMethod() {
+    assertTrue(true);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/ConstructorSingleArgumentTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ConstructorSingleArgumentTest.java
@@ -1,0 +1,19 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstJUnit4.class)
+public final class ConstructorSingleArgumentTest {
+  private final Soda soda;
+
+  public ConstructorSingleArgumentTest(Soda soda) {
+    this.soda = soda;
+  }
+
+  @Test public void testMethod() {
+    assertNotNull(soda);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/JournalingListener.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/JournalingListener.java
@@ -1,0 +1,58 @@
+package com.squareup.burst;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+
+final class JournalingListener {
+  private final RunNotifier notifier = new RunNotifier();
+  private final List<String> journal = new ArrayList<>();
+
+  JournalingListener() {
+    notifier.addListener(new RunListener() {
+      @Override public void testRunStarted(Description description) throws Exception {
+        throw new AssertionError();
+      }
+
+      @Override public void testRunFinished(Result result) throws Exception {
+        throw new AssertionError();
+      }
+
+      @Override public void testStarted(Description description) throws Exception {
+        journal.add("START " + description.getDisplayName());
+      }
+
+      @Override public void testFinished(Description description) throws Exception {
+        journal.add("FINISH " + description.getDisplayName());
+      }
+
+      @Override public void testFailure(Failure failure) throws Exception {
+        journal.add(
+            "FAIL " + failure.getDescription().getDisplayName() + " " + failure.getMessage());
+      }
+
+      @Override public void testAssumptionFailure(Failure failure) {
+        journal.add("ASSUMPTION FAIL "
+            + failure.getDescription().getDisplayName()
+            + " "
+            + failure.getMessage());
+      }
+
+      @Override public void testIgnored(Description description) throws Exception {
+        journal.add("IGNORE " + description.getDisplayName());
+      }
+    });
+  }
+
+  RunNotifier notifier() {
+    return notifier;
+  }
+
+  List<String> journal() {
+    return new ArrayList<>(journal);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/MethodTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/MethodTest.java
@@ -1,0 +1,23 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstJUnit4.class)
+public final class MethodTest {
+  @Test public void none() {
+    assertTrue(true);
+  }
+
+  @Test public void single(Soda soda) {
+    assertNotNull(soda);
+  }
+
+  @Test public void multiple(Soda soda, Snack snack) {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/Snack.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/Snack.java
@@ -1,0 +1,5 @@
+package com.squareup.burst;
+
+public enum Snack {
+  CHIPS, NUTS, CANDY
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/Soda.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/Soda.java
@@ -1,0 +1,5 @@
+package com.squareup.burst;
+
+public enum Soda {
+  PEPSI, COKE, RC_COLA;
+}

--- a/burst/src/main/java/com/squareup/burst/Burst.java
+++ b/burst/src/main/java/com/squareup/burst/Burst.java
@@ -57,27 +57,23 @@ public final class Burst {
    * @throws ClassCastException If any element of {@code constructorArgs} or {@code methodArgs} is
    * not an enum value.
    */
-  public static String explodedName(String name, Object[] constructorArgs, Object[] methodArgs) {
-    checkNotNull(name, "name");
-    checkNotNull(constructorArgs, "constructorArgs");
-    checkNotNull(methodArgs, "methodArgs");
-
-    StringBuilder builder = new StringBuilder(name);
-    for (Object argument : constructorArgs) {
-      Enum<?> value = (Enum<?>) argument;
-      // Appends the enum name and value name. (e.g., Card.VISA)
-      builder.append('_').append(getQualifiedEnumName(value));
+  public static String friendlyName(Object[] arguments) {
+    checkNotNull(arguments, "arguments");
+    if (arguments.length == 0) {
+      return "";
     }
-    for (Object argument : methodArgs) {
+
+    StringBuilder builder = new StringBuilder();
+    for (Object argument : arguments) {
+      if (builder.length() > 0) {
+        builder.append(", ");
+      }
+
       Enum<?> value = (Enum<?>) argument;
       // Appends the enum name and value name. (e.g., Card.VISA)
-      builder.append('_').append(getQualifiedEnumName(value));
+      builder.append(value.getClass().getSimpleName()).append('.').append(value);
     }
     return builder.toString();
-  }
-
-  private static String getQualifiedEnumName(Enum<?> value) {
-    return value.getClass().getSimpleName() + '.' + value;
   }
 
   private static Object[][] explodeParameters(Class<?>[] parameterTypes, String name) {

--- a/burst/src/test/java/com/squareup/burst/BurstTest.java
+++ b/burst/src/test/java/com/squareup/burst/BurstTest.java
@@ -192,9 +192,9 @@ public class BurstTest {
     );
   }
 
-  @Test public void nonEnumConstructorArgumentNameFails() {
+  @Test public void nonEnumArgumentsFail() {
     try {
-      Burst.explodedName("nope", new Object[] { "NOPE" }, new Object[] { First.APPLE });
+      Burst.friendlyName(new Object[] { "NOPE" });
       fail();
     } catch (ClassCastException e) {
       // TODO is this message an implementation detail of Java?
@@ -202,62 +202,18 @@ public class BurstTest {
     }
   }
 
-  @Test public void nonEnumMethodArgumentNameFails() {
-    try {
-      Burst.explodedName("nope", new Object[] { First.APPLE }, new Object[] { "NOPE" });
-      fail();
-    } catch (ClassCastException e) {
-      // TODO is this message an implementation detail of Java?
-      assertThat(e).hasMessage("java.lang.String cannot be cast to java.lang.Enum");
-    }
+  @Test public void noArguments() {
+    String actual = Burst.friendlyName(new Object[0]);
+    assertThat(actual).isEqualTo("");
   }
 
-  @Test public void noArgumentsName() {
-    String name = "helloWorld";
-    String actual = Burst.explodedName(name, new Object[0], new Object[0]);
-    assertThat(actual).isEqualTo("helloWorld");
+  @Test public void singleArgument() {
+    String actual = Burst.friendlyName(new Object[] { First.APPLE });
+    assertThat(actual).isEqualTo("First.APPLE");
   }
 
-  @Test public void singleConstructorArgumentName() {
-    String name = "helloWorld";
-    String actual = Burst.explodedName(name, new Object[] { First.APPLE }, new Object[0]);
-    assertThat(actual).isEqualTo("helloWorld_First.APPLE");
-  }
-
-  @Test public void singleMethodArgumentName() {
-    String name = "helloWorld";
-    String actual = Burst.explodedName(name, new Object[0], new Object[] { First.APPLE });
-    assertThat(actual).isEqualTo("helloWorld_First.APPLE");
-  }
-
-  @Test public void singleConstructorAndMethodArgumentName() {
-    String name = "helloWorld";
-    String actual =
-        Burst.explodedName(name, new Object[] { First.APPLE }, new Object[] { First.BEARD });
-    assertThat(actual).isEqualTo("helloWorld_First.APPLE_First.BEARD");
-  }
-
-  @Test public void multipleConstructorArgumentsName() {
-    String name = "helloWorld";
-    String actual =
-        Burst.explodedName(name, new Object[] { First.APPLE, Second.DINGO, Third.FRANK },
-            new Object[0]);
-    assertThat(actual).isEqualTo("helloWorld_First.APPLE_Second.DINGO_Third.FRANK");
-  }
-
-  @Test public void multipleMethodArgumentsName() {
-    String name = "helloWorld";
-    String actual = Burst.explodedName(name, new Object[0],
-        new Object[] { First.APPLE, Second.DINGO, Third.FRANK });
-    assertThat(actual).isEqualTo("helloWorld_First.APPLE_Second.DINGO_Third.FRANK");
-  }
-
-  @Test public void multipleConstructorAndMethodArgumentsName() {
-    String name = "helloWorld";
-    String actual =
-        Burst.explodedName(name, new Object[] { First.APPLE, Second.DINGO, Third.FRANK },
-            new Object[] { First.BEARD, Second.EAGLE, Third.GREAT });
-    assertThat(actual).isEqualTo(
-        "helloWorld_First.APPLE_Second.DINGO_Third.FRANK_First.BEARD_Second.EAGLE_Third.GREAT");
+  @Test public void multipleArguments() {
+    String actual = Burst.friendlyName(new Object[] { First.APPLE, Second.EAGLE, Third.ITALY });
+    assertThat(actual).isEqualTo("First.APPLE, Second.EAGLE, Third.ITALY");
   }
 }


### PR DESCRIPTION
Break up the name helper since we use it differently and separately between JUnit 3 (Android) and JUnit 4.

```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO]
[INFO] Burst (Parent) ..................................... SUCCESS [  0.902 s]
[INFO] Burst .............................................. SUCCESS [  3.038 s]
[INFO] Burst Android Integration .......................... SUCCESS [  0.611 s]
[INFO] Burst JUnit 4 Integration .......................... SUCCESS [  1.070 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 5.773 s
[INFO] Finished at: 2014-09-16T17:05:32-07:00
[INFO] Final Memory: 29M/382M
[INFO] ------------------------------------------------------------------------
```
