### PR TITLE
Declare test args as Enum<?> everywhere

### DIFF
--- a/burst-android/src/main/java/com/squareup/burst/BurstAndroid.java
+++ b/burst-android/src/main/java/com/squareup/burst/BurstAndroid.java
@@ -47,7 +47,7 @@ public class BurstAndroid extends AndroidTestRunner {
     Class<?> testClass = classLoader.loadClass(testSuite.getName());
 
     Constructor<?> constructor = findBurstableConstructor(testClass);
-    Object[][] constructorArgsList = Burst.explodeArguments(constructor);
+    Enum<?>[][] constructorArgsList = Burst.explodeArguments(constructor);
 
     @SuppressWarnings("unchecked") Enumeration<Test> testEnumerator = testSuite.tests();
     while (testEnumerator.hasMoreElements()) {
@@ -55,9 +55,9 @@ public class BurstAndroid extends AndroidTestRunner {
       if (test instanceof TestCase) {
         TestCase testCase = (TestCase) test;
         Method method = testClass.getMethod(testCase.getName());
-        for (Object[] methodArgs : Burst.explodeArguments(method)) {
+        for (Enum<?>[] methodArgs : Burst.explodeArguments(method)) {
           // Loop constructor args last so we only iterate and explode each test method once.
-          for (Object[] constructorArgs : constructorArgsList) {
+          for (Enum<?>[] constructorArgs : constructorArgsList) {
             String name = nameWithArguments(method.getName(), constructorArgs, methodArgs);
             // We can't call setName(name) - that would break TestCase's runTest which reflectively
             // invokes methods by name. Instead we generate a new class which overrides getName.
@@ -105,8 +105,8 @@ public class BurstAndroid extends AndroidTestRunner {
     throw new AssertionError("JUnit should have rejected this class: " + cls.getName());
   }
 
-  private static String nameWithArguments(String name, Object[] constructorArgs,
-      Object[] methodArgs) {
+  private static String nameWithArguments(String name, Enum<?>[] constructorArgs,
+      Enum<?>[] methodArgs) {
     StringBuilder builder = new StringBuilder(name);
     if (constructorArgs.length > 0) {
       builder.append('[').append(Burst.friendlyName(constructorArgs)).append(']');

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
@@ -28,15 +28,15 @@ public final class BurstJUnit4 extends Suite {
     List<FrameworkMethod> burstMethods = new ArrayList<>(testMethods.size());
     for (FrameworkMethod testMethod : testMethods) {
       Method method = testMethod.getMethod();
-      for (Object[] methodArgs : Burst.explodeArguments(method)) {
+      for (Enum<?>[] methodArgs : Burst.explodeArguments(method)) {
         burstMethods.add(new BurstMethod(method, methodArgs));
       }
     }
 
     Constructor<?> constructor = findConstructor(cls);
-    Object[][] constructorArgsList = Burst.explodeArguments(constructor);
+    Enum<?>[][] constructorArgsList = Burst.explodeArguments(constructor);
     List<Runner> burstRunners = new ArrayList<>(constructorArgsList.length);
-    for (Object[] constructorArgs : constructorArgsList) {
+    for (Enum<?>[] constructorArgs : constructorArgsList) {
       burstRunners.add(new BurstRunner(cls, constructor, constructorArgs, burstMethods));
     }
 
@@ -54,7 +54,7 @@ public final class BurstJUnit4 extends Suite {
     throw new IllegalStateException(cls.getName() + " requires a single public constructor.");
   }
 
-  static String nameWithArguments(String name, Object[] arguments) {
+  static String nameWithArguments(String name, Enum<?>[] arguments) {
     if (arguments.length == 0) {
       return name;
     }

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
@@ -8,9 +8,9 @@ import static com.squareup.burst.BurstJUnit4.nameWithArguments;
 import static com.squareup.burst.Util.checkNotNull;
 
 final class BurstMethod extends FrameworkMethod {
-  private final Object[] methodArgs;
+  private final Enum<?>[] methodArgs;
 
-  BurstMethod(Method method, Object[] methodArgs) {
+  BurstMethod(Method method, Enum<?>[] methodArgs) {
     super(checkNotNull(method, "method"));
     this.methodArgs = checkNotNull(methodArgs, "methodArgs");
   }

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
@@ -13,10 +13,10 @@ import static com.squareup.burst.Util.checkNotNull;
 
 final class BurstRunner extends BlockJUnit4ClassRunner {
   private final Constructor<?> constructor;
-  private final Object[] constructorArgs;
+  private final Enum<?>[] constructorArgs;
   private final List<FrameworkMethod> methods;
 
-  BurstRunner(Class<?> cls, Constructor<?> constructor, Object[] constructorArgs,
+  BurstRunner(Class<?> cls, Constructor<?> constructor, Enum<?>[] constructorArgs,
       List<FrameworkMethod> methods) throws InitializationError {
     super(checkNotNull(cls, "cls"));
     this.constructor = checkNotNull(constructor, "constructor");

--- a/burst/src/main/java/com/squareup/burst/Burst.java
+++ b/burst/src/main/java/com/squareup/burst/Burst.java
@@ -10,13 +10,13 @@ import static com.squareup.burst.Util.checkNotNull;
  * constructors and methods.
  */
 public final class Burst {
-  private static final Object[][] NONE = new Object[1][0];
+  private static final Enum<?>[][] NONE = new Enum<?>[1][0];
 
   /**
    * Explode a list of argument values for invoking the specified constructor with all combinations
    * of its parameters.
    */
-  public static Object[][] explodeArguments(Constructor<?> constructor) {
+  public static Enum<?>[][] explodeArguments(Constructor<?> constructor) {
     checkNotNull(constructor, "constructor");
 
     return explodeParameters(constructor.getParameterTypes(),
@@ -27,7 +27,7 @@ public final class Burst {
    * Explode a list of argument values for invoking the specified method with all combinations of
    * its parameters.
    */
-  public static Object[][] explodeArguments(Method method) {
+  public static Enum<?>[][] explodeArguments(Method method) {
     checkNotNull(method, "method");
 
     return explodeParameters(method.getParameterTypes(),
@@ -46,7 +46,7 @@ public final class Burst {
    * @throws ClassCastException If any element of {@code constructorArgs} or {@code methodArgs} is
    * not an enum value.
    */
-  public static String friendlyName(Object[] arguments) {
+  public static String friendlyName(Enum<?>[] arguments) {
     checkNotNull(arguments, "arguments");
     if (arguments.length == 0) {
       return "";
@@ -65,7 +65,7 @@ public final class Burst {
     return builder.toString();
   }
 
-  private static Object[][] explodeParameters(Class<?>[] parameterTypes, String name) {
+  private static Enum<?>[][] explodeParameters(Class<?>[] parameterTypes, String name) {
     int parameterCount = parameterTypes.length;
     if (parameterCount == 0) {
       return NONE;
@@ -94,13 +94,13 @@ public final class Burst {
     return explode(count, valuesList);
   }
 
-  private static Object[][] explode(int count, Enum<?>[][] valuesList) {
+  private static Enum<?>[][] explode(int count, Enum<?>[][] valuesList) {
     // The number of times to replay iterating over individual enum values.
     int replays = 1;
     // The number of times to repeat an enum value.
     int adjacent = count;
 
-    Object[][] arguments = new Object[count][valuesList.length];
+    Enum<?>[][] arguments = new Enum<?>[count][valuesList.length];
     for (int valuesIndex = 0; valuesIndex < valuesList.length; valuesIndex++) {
       Enum<?>[] values = valuesList[valuesIndex];
 

--- a/burst/src/test/java/com/squareup/burst/BurstTest.java
+++ b/burst/src/test/java/com/squareup/burst/BurstTest.java
@@ -150,28 +150,18 @@ public class BurstTest {
     );
   }
 
-  @Test public void nonEnumArgumentsFail() {
-    try {
-      Burst.friendlyName(new Object[] { "NOPE" });
-      fail();
-    } catch (ClassCastException e) {
-      // TODO is this message an implementation detail of Java?
-      assertThat(e).hasMessage("java.lang.String cannot be cast to java.lang.Enum");
-    }
-  }
-
   @Test public void noArguments() {
-    String actual = Burst.friendlyName(new Object[0]);
+    String actual = Burst.friendlyName(new Enum<?>[0]);
     assertThat(actual).isEqualTo("");
   }
 
   @Test public void singleArgument() {
-    String actual = Burst.friendlyName(new Object[] { First.APPLE });
+    String actual = Burst.friendlyName(new Enum<?>[] { First.APPLE });
     assertThat(actual).isEqualTo("First.APPLE");
   }
 
   @Test public void multipleArguments() {
-    String actual = Burst.friendlyName(new Object[] { First.APPLE, Second.EAGLE, Third.ITALY });
+    String actual = Burst.friendlyName(new Enum<?>[] { First.APPLE, Second.EAGLE, Third.ITALY });
     assertThat(actual).isEqualTo("First.APPLE, Second.EAGLE, Third.ITALY");
   }
 }


### PR DESCRIPTION
To add a bit of extra type safety. Makes the `nonEnumArgumentsFail()` test unnecessary.
