### PR TITLE
Robolectric 2.3 support without any Robolectric modifications

### DIFF
--- a/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
@@ -1,25 +1,28 @@
 package com.squareup.burst;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.Runner;
+import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.Suite;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.TestClass;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.squareup.burst.Util.checkNotNull;
 import static java.util.Collections.unmodifiableList;
 
 public final class BurstJUnit4 extends Suite {
   public BurstJUnit4(Class<?> cls) throws InitializationError {
-    super(cls, explode(cls));
+    super(cls, explode(cls, BurstRunner.class));
   }
 
-  static List<Runner> explode(Class<?> cls) throws InitializationError {
+  static List<Runner> explode(Class<?> cls, Class<? extends BlockJUnit4ClassRunner> runnerCls)
+      throws InitializationError {
     checkNotNull(cls, "cls");
 
     TestClass testClass = new TestClass(cls);
@@ -37,10 +40,23 @@ public final class BurstJUnit4 extends Suite {
     Enum<?>[][] constructorArgsList = Burst.explodeArguments(constructor);
     List<Runner> burstRunners = new ArrayList<>(constructorArgsList.length);
     for (Enum<?>[] constructorArgs : constructorArgsList) {
-      burstRunners.add(new BurstRunner(cls, constructor, constructorArgs, burstMethods));
+      burstRunners.add(createRunner(runnerCls, cls, constructor, constructorArgs, burstMethods));
     }
 
     return unmodifiableList(burstRunners);
+  }
+
+  static Runner createRunner(Class<? extends Runner> runnerCls, Class<?> cls,
+      Constructor<?> constructor, Enum<?>[] constructorArgs, List<FrameworkMethod> methods) {
+    try {
+      Constructor runnerConstructor = runnerCls.getDeclaredConstructor(
+          Class.class, Constructor.class, Enum[].class, List.class);
+      return (Runner) runnerConstructor.newInstance(cls, constructor, constructorArgs, methods);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException("Runner must have constructor with params: Class, Constructor, Enum[], List", e);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Unable to instantiate test runner", e);
+    }
   }
 
   /** Locate the default or public constructor for a test class. */

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstJUnit4.java
@@ -53,7 +53,8 @@ public final class BurstJUnit4 extends Suite {
           Class.class, Constructor.class, Enum[].class, List.class);
       return (Runner) runnerConstructor.newInstance(cls, constructor, constructorArgs, methods);
     } catch (NoSuchMethodException e) {
-      throw new RuntimeException("Runner must have constructor with params: Class, Constructor, Enum[], List", e);
+      throw new RuntimeException("Runner must have constructor with params: Class, Constructor, "
+          + "Enum[], List", e);
     } catch (ReflectiveOperationException e) {
       throw new RuntimeException("Unable to instantiate test runner", e);
     }

--- a/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstMethod.java
@@ -30,4 +30,8 @@ final class BurstMethod extends FrameworkMethod {
   @Override public String getName() {
     return nameWithArguments(super.getName(), methodArgs);
   }
+
+  Enum[] getMethodArgs() {
+    return methodArgs;
+  }
 }

--- a/burst-robolectric/AndroidManifest.xml
+++ b/burst-robolectric/AndroidManifest.xml
@@ -2,9 +2,8 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
         package="com.squareup.burst.robolectric">
-
   <uses-sdk
       android:minSdkVersion="15"
-      android:targetSdkVersion="20"
-      />
+      android:targetSdkVersion="20" />
+  <application />
 </manifest>

--- a/burst-robolectric/AndroidManifest.xml
+++ b/burst-robolectric/AndroidManifest.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+        package="com.squareup.burst.robolectric">
+
+  <uses-sdk
+      android:minSdkVersion="15"
+      android:targetSdkVersion="20"
+      />
+</manifest>

--- a/burst-robolectric/pom.xml
+++ b/burst-robolectric/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <version>2.3</version>
+      <scope>optional</scope>
     </dependency>
     <dependency>
       <groupId>com.google.android</groupId>
@@ -50,11 +50,20 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
-
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.easytesting</groupId>
+      <artifactId>fest-reflect</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-ant-tasks</artifactId>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
 </project>

--- a/burst-robolectric/pom.xml
+++ b/burst-robolectric/pom.xml
@@ -30,16 +30,66 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>com.squareup.burst</groupId>
-      <artifactId>burst-android-test-app</artifactId>
-      <version>${project.version}</version>
-      <scope>provided</scope>
-      <type>apk</type>
-    </dependency>
-    <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>
-      <scope>optional</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-model</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-settings</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-error-diagnostics</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-project</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-repository-metadata</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven</groupId>
+          <artifactId>maven-artifact-manager</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.wagon</groupId>
+          <artifactId>wagon-http-lightweight</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.wagon</groupId>
+          <artifactId>wagon-file</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.maven.wagon</groupId>
+          <artifactId>wagon-provider-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-container-default</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-interpolation</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.codehaus.plexus</groupId>
+          <artifactId>plexus-utils</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>classworlds</groupId>
+          <artifactId>classworlds</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.google.android</groupId>
@@ -58,11 +108,6 @@
     <dependency>
       <groupId>org.easytesting</groupId>
       <artifactId>fest-reflect</artifactId>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-ant-tasks</artifactId>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/burst-robolectric/pom.xml
+++ b/burst-robolectric/pom.xml
@@ -23,6 +23,19 @@
       <artifactId>burst-junit4</artifactId>
       <version>${project.version}</version>
     </dependency>
+      <dependency>
+      <groupId>com.squareup.burst</groupId>
+      <artifactId>burst-android-test-app</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.burst</groupId>
+      <artifactId>burst-android-test-app</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+      <type>apk</type>
+    </dependency>
     <dependency>
       <groupId>org.robolectric</groupId>
       <artifactId>robolectric</artifactId>

--- a/burst-robolectric/pom.xml
+++ b/burst-robolectric/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>com.squareup.burst</groupId>
+    <artifactId>burst-parent</artifactId>
+    <version>1.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>burst-robolectric</artifactId>
+  <name>Burst Robolectric Integration</name>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.squareup.burst</groupId>
+      <artifactId>burst</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup.burst</groupId>
+      <artifactId>burst-junit4</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.robolectric</groupId>
+      <artifactId>robolectric</artifactId>
+      <version>2.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android-test</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectric.java
+++ b/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectric.java
@@ -1,21 +1,9 @@
 package com.squareup.burst;
 
-import org.junit.Test;
-import org.junit.runner.Runner;
 import org.junit.runners.Suite;
-import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
-import org.junit.runners.model.TestClass;
-import org.robolectric.RobolectricTestRunner;
-
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.squareup.burst.BurstJUnit4.explode;
-import static com.squareup.burst.Util.checkNotNull;
-import static java.util.Collections.unmodifiableList;
 
 public class BurstRobolectric extends Suite {
   public BurstRobolectric(Class<?> cls) throws InitializationError {

--- a/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectric.java
+++ b/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectric.java
@@ -1,0 +1,24 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.Runner;
+import org.junit.runners.Suite;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.TestClass;
+import org.robolectric.RobolectricTestRunner;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.squareup.burst.BurstJUnit4.explode;
+import static com.squareup.burst.Util.checkNotNull;
+import static java.util.Collections.unmodifiableList;
+
+public class BurstRobolectric extends Suite {
+  public BurstRobolectric(Class<?> cls) throws InitializationError {
+    super(cls, explode(cls, BurstRobolectricRunner.class));
+  }
+}

--- a/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectricRunner.java
+++ b/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectricRunner.java
@@ -1,14 +1,20 @@
 package com.squareup.burst;
 
+import android.app.Application;
 import android.os.Build;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
-import org.robolectric.AndroidManifest;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.SdkEnvironment;
+import org.junit.runners.model.TestClass;
+import org.robolectric.*;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.WithConstantInt;
+import org.robolectric.annotation.WithConstantString;
+import org.robolectric.internal.ParallelUniverse;
 import org.robolectric.internal.ParallelUniverseInterface;
 import org.robolectric.res.ResourceLoader;
 
@@ -16,86 +22,107 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.security.SecureRandom;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
 import static com.squareup.burst.BurstJUnit4.nameWithArguments;
 import static com.squareup.burst.Util.checkNotNull;
-import static org.fest.reflect.core.Reflection.staticField;
+import static org.fest.reflect.core.Reflection.*;
+
 
 public class BurstRobolectricRunner extends RobolectricTestRunner {
-  private final Constructor<?> constructor;
   private final Enum<?>[] constructorArgs;
   private final List<FrameworkMethod> methods;
 
-  public BurstRobolectricRunner(Class<?> cls, Constructor<?> constructor, Enum<?>[] constructorArgs,
-                                List<FrameworkMethod> methods) throws InitializationError {
+  @SuppressWarnings("UnusedParameters")
+  BurstRobolectricRunner(Class<?> cls, Constructor<?> ignored, Enum<?>[] constructorArgs,
+              List<FrameworkMethod> methods) throws InitializationError {
     super(checkNotNull(cls, "cls"));
-    this.constructor = checkNotNull(constructor, "constructor");
     this.constructorArgs = checkNotNull(constructorArgs, "constructorArgs");
     this.methods = checkNotNull(methods, "methods");
+
+    EnvHolder envHolder;
+    synchronized (envHoldersByTestRunner) {
+      Class<? extends BurstRobolectricRunner> testRunnerClass = getClass();
+      envHolder = envHoldersByTestRunner.get(testRunnerClass);
+      if (envHolder == null) {
+        envHolder = new EnvHolder();
+        envHoldersByTestRunner.put(testRunnerClass, envHolder);
+      }
+    }
+    this.envHolder = envHolder;
+  }
+
+  @Override protected List<FrameworkMethod> getChildren() {
+    return methods;
+  }
+
+  @Override protected String getName() {
+    return nameWithArguments(super.getName(), constructorArgs);
+  }
+
+  @Override protected Description describeChild(FrameworkMethod method) {
+    return Description.createTestDescription(getName(), method.getName());
   }
 
   @Override protected void validateConstructor(List<Throwable> errors) {
     // Constructor was already validated by Burst.
   }
 
-  @Override
-  protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation,
-                                                boolean isStatic, List<Throwable> errors) {
+  @Override protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation,
+                                                          boolean isStatic, List<Throwable> errors) {
     // Methods were already validated by Burst.
   }
 
-  @Override
-  protected List<FrameworkMethod> getChildren() {
-    return methods;
+  private static final MavenCentral MAVEN_CENTRAL = new MavenCentral();
+  private static final Map<Class<? extends BurstRobolectricRunner>, EnvHolder> envHoldersByTestRunner = new HashMap<>();
+  private final EnvHolder envHolder;
+  private TestLifecycle<Application> testLifecycle;
+
+  static {
+    new SecureRandom(); // this starts up the Poller SunPKCS11-Darwin thread early, outside of any Robolectric classloader
   }
 
-  @Override
-  protected String getName() {
-    return nameWithArguments(super.getName(), constructorArgs);
-  }
+  private Class<? extends BurstRobolectricRunner> lastTestRunnerClass;
+  private SdkConfig lastSdkConfig;
+  private SdkEnvironment lastSdkEnvironment;
+  private final HashSet<Class<?>> loadedTestClasses = new HashSet<Class<?>>();
 
-  @Override
-  protected Description describeChild(FrameworkMethod method) {
-    return Description.createTestDescription(getName(), method.getName());
-  }
-
-
-  @Override
-  public Object createTest() throws Exception {
-    return constructor.newInstance(constructorArgs);
-  }
-
-  @Override
-  protected HelperTestRunner getHelperTestRunner(final Class bootstrappedTestClass) {
+  private void assureTestLifecycle(SdkEnvironment sdkEnvironment) {
     try {
-      return new HelperTestRunner(bootstrappedTestClass) {
-        @Override protected void validateConstructor(List<Throwable> errors) {
-          BurstRobolectricRunner.this.validateConstructor(errors);
-        }
+      ClassLoader robolectricClassLoader = sdkEnvironment.getRobolectricClassLoader();
+      testLifecycle = (TestLifecycle) robolectricClassLoader.loadClass(getTestLifecycleClass().getName()).newInstance();
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
-        @Override
-        protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation, boolean isStatic,
-            List<Throwable> errors) {
-          BurstRobolectricRunner.this.validatePublicVoidNoArgMethods(annotation, isStatic, errors);
-        }
-
-        @Override
-        protected Object createTest() throws Exception {
-          Constructor<?> parallelConstructor = bootstrappedTestClass.getConstructors()[0];
-          Enum[] parallelArgs = new Enum[parallelConstructor.getParameterTypes().length];
-          for (int i = 0; i < constructorArgs.length; i++) {
-            Class<? extends Enum> enumClass = (Class<? extends Enum>) parallelConstructor.getParameterTypes()[i];
-            String enumName = constructorArgs[i].name();
-            parallelArgs[i] = Enum.valueOf(enumClass, enumName);
+  @Override
+  protected Statement classBlock(RunNotifier notifier) {
+    final Statement statement = childrenInvoker(notifier);
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        try {
+          statement.evaluate();
+          for (Class<?> testClass : loadedTestClasses) {
+            invokeAfterClass(testClass);
           }
-
-          return parallelConstructor.newInstance(parallelArgs);
+        } finally {
+          afterClass();
         }
-      };
-    } catch (InitializationError initializationError) {
-      throw new RuntimeException(initializationError);
+      }
+    };
+  }
+
+  private void invokeAfterClass(final Class<?> clazz) throws Throwable {
+    final TestClass testClass = new TestClass(clazz);
+    final List<FrameworkMethod> afters = testClass.getAnnotatedMethods(AfterClass.class);
+    for (FrameworkMethod after : afters) {
+      after.invokeExplosively(null);
     }
   }
 
@@ -110,7 +137,7 @@ public class BurstRobolectricRunner extends RobolectricTestRunner {
         Thread.currentThread().setContextClassLoader(sdkEnvironment.getRobolectricClassLoader());
 
         Class bootstrappedTestClass = sdkEnvironment.bootstrappedClass(getTestClass().getJavaClass());
-        HelperTestRunner helperTestRunner = getHelperTestRunner(bootstrappedTestClass);
+        BurstHelperTestRunner helperTestRunner = getHelperTestRunner(bootstrappedTestClass);
 
         Method bootstrappedMethod = null;
         Method[] declaredMethods = bootstrappedTestClass.getDeclaredMethods();
@@ -187,5 +214,190 @@ public class BurstRobolectricRunner extends RobolectricTestRunner {
         }
       }
     };
+  }
+
+  private void invokeBeforeClass(final Class clazz) throws Throwable {
+    if (!loadedTestClasses.contains(clazz)) {
+      loadedTestClasses.add(clazz);
+
+      final TestClass testClass = new TestClass(clazz);
+      final List<FrameworkMethod> befores = testClass.getAnnotatedMethods(BeforeClass.class);
+      for (FrameworkMethod before : befores) {
+        before.invokeExplosively(null);
+      }
+    }
+  }
+
+  @Override
+  protected BurstHelperTestRunner getHelperTestRunner(Class bootstrappedTestClass) {
+    try {
+      return new BurstHelperTestRunner(bootstrappedTestClass);
+    } catch (InitializationError initializationError) {
+      throw new RuntimeException(initializationError);
+    }
+  }
+
+  private SdkEnvironment getEnvironment(final AndroidManifest appManifest, final Config config) {
+    final SdkConfig sdkConfig = pickSdkVersion(appManifest, config);
+
+    // keep the most recently-used SdkEnvironment strongly reachable to prevent thrashing in low-memory situations.
+    if (getClass().equals(lastTestRunnerClass) && sdkConfig.equals(lastSdkConfig)) {
+      return lastSdkEnvironment;
+    }
+
+    lastTestRunnerClass = null;
+    lastSdkConfig = null;
+    lastSdkEnvironment = envHolder.getSdkEnvironment(sdkConfig, new SdkEnvironment.Factory() {
+      @Override public SdkEnvironment create() {
+        return createSdkEnvironment(sdkConfig);
+      }
+    });
+    lastTestRunnerClass = getClass();
+    lastSdkConfig = sdkConfig;
+    return lastSdkEnvironment;
+  }
+
+  @Override
+  protected void setUpApplicationState(Method method, ParallelUniverseInterface parallelUniverseInterface, boolean strictI18n, ResourceLoader systemResourceLoader, AndroidManifest appManifest, Config config) {
+    parallelUniverseInterface.setUpApplicationState(method, testLifecycle, strictI18n, systemResourceLoader, appManifest, config);
+  }
+
+  private ParallelUniverseInterface getHooksInterface(SdkEnvironment sdkEnvironment) {
+    ClassLoader robolectricClassLoader = sdkEnvironment.getRobolectricClassLoader();
+    Class<? extends ParallelUniverseInterface> parallelUniverseClass =
+        type(ParallelUniverse.class.getName())
+            .withClassLoader(robolectricClassLoader)
+            .loadAs(ParallelUniverseInterface.class);
+
+    return constructor()
+        .withParameterTypes(RobolectricTestRunner.class)
+        .in(parallelUniverseClass)
+        .newInstance(this);
+  }
+
+  @Override
+  public void internalAfterTest(final Method method) {
+    testLifecycle.afterTest(method);
+  }
+
+  private void afterClass() {
+    testLifecycle = null;
+  }
+
+  /**
+   * Find all the class and method annotations and pass them to
+   * addConstantFromAnnotation() for evaluation.
+   * <p/>
+   * TODO: Add compound annotations to support defining more than one int and string at a time
+   * TODO: See http://stackoverflow.com/questions/1554112/multiple-annotations-of-the-same-type-on-one-element
+   *
+   * @param method
+   * @return
+   */
+  private Map<Field, Object> getWithConstantAnnotations(Method method) {
+    Map<Field, Object> constants = new HashMap<Field, Object>();
+
+    for (Annotation anno : method.getDeclaringClass().getAnnotations()) {
+      addConstantFromAnnotation(constants, anno);
+    }
+
+    for (Annotation anno : method.getAnnotations()) {
+      addConstantFromAnnotation(constants, anno);
+    }
+
+    return constants;
+  }
+
+
+  /**
+   * If the annotation is a constant redefinition, add it to the provided hash
+   *
+   * @param constants
+   * @param anno
+   */
+  private void addConstantFromAnnotation(Map<Field, Object> constants, Annotation anno) {
+    try {
+      String name = anno.annotationType().getName();
+      Object newValue = null;
+
+      if (name.equals(WithConstantString.class.getName())) {
+        newValue = anno.annotationType().getMethod("newValue").invoke(anno);
+      } else if (name.equals(WithConstantInt.class.getName())) {
+        newValue = anno.annotationType().getMethod("newValue").invoke(anno);
+      } else {
+        return;
+      }
+
+      @SuppressWarnings("rawtypes")
+      Class classWithField = (Class) anno.annotationType().getMethod("classWithField").invoke(anno);
+      String fieldName = (String) anno.annotationType().getMethod("fieldName").invoke(anno);
+      Field field = classWithField.getDeclaredField(fieldName);
+      constants.put(field, newValue);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Defines static finals from the provided hash and stores the old values back
+   * into the hash.
+   * <p/>
+   * Call it twice with the same hash, and it puts everything back the way it was originally.
+   *
+   * @param constants
+   */
+  private void setupConstants(Map<Field, Object> constants) {
+    for (Field field : constants.keySet()) {
+      Object newValue = constants.get(field);
+      Object oldValue = Robolectric.Reflection.setFinalStaticField(field, newValue);
+      constants.put(field, oldValue);
+    }
+  }
+
+  public class BurstHelperTestRunner extends HelperTestRunner {
+    public BurstHelperTestRunner(Class<?> testClass) throws InitializationError {
+      super(testClass);
+    }
+
+    @Override public Statement classBlock(RunNotifier notifier) {
+      return super.classBlock(notifier);
+    }
+
+    @Override public Statement methodBlock(FrameworkMethod method) {
+      return super.methodBlock(method);
+    }
+
+    @Override protected void validateConstructor(List<Throwable> errors) {
+      BurstRobolectricRunner.this.validateConstructor(errors);
+    }
+
+    @Override
+    protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation, boolean isStatic,
+                                                  List<Throwable> errors) {
+      BurstRobolectricRunner.this.validatePublicVoidNoArgMethods(annotation, isStatic, errors);
+    }
+
+    @Override
+    protected Object createTest() throws Exception {
+      Constructor<?> parallelConstructor = null;
+      Constructor<?>[] constructors = getTestClass().getJavaClass().getConstructors();
+      for (Constructor<?> aConstructor : constructors) {
+        if (aConstructor.getParameterTypes().length == constructorArgs.length) {
+          parallelConstructor = aConstructor;
+        }
+      }
+      if (parallelConstructor == null) {
+        throw new IllegalStateException("Got lost in the parallel universe");
+      }
+      Enum[] parallelArgs = new Enum[parallelConstructor.getParameterTypes().length];
+      for (int i = 0; i < constructorArgs.length; i++) {
+        Class<? extends Enum> enumClass = (Class<? extends Enum>) parallelConstructor.getParameterTypes()[i];
+        String enumName = constructorArgs[i].name();
+        parallelArgs[i] = Enum.valueOf(enumClass, enumName);
+      }
+      Object test = parallelConstructor.newInstance(parallelArgs);
+      testLifecycle.prepareTest(test);
+      return test;
+    }
   }
 }

--- a/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectricRunner.java
+++ b/burst-robolectric/src/main/java/com/squareup/burst/BurstRobolectricRunner.java
@@ -1,0 +1,191 @@
+package com.squareup.burst;
+
+import android.os.Build;
+import org.junit.runner.Description;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import org.robolectric.AndroidManifest;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.SdkEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.internal.ParallelUniverseInterface;
+import org.robolectric.res.ResourceLoader;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+
+import static com.squareup.burst.BurstJUnit4.nameWithArguments;
+import static com.squareup.burst.Util.checkNotNull;
+import static org.fest.reflect.core.Reflection.staticField;
+
+public class BurstRobolectricRunner extends RobolectricTestRunner {
+  private final Constructor<?> constructor;
+  private final Enum<?>[] constructorArgs;
+  private final List<FrameworkMethod> methods;
+
+  public BurstRobolectricRunner(Class<?> cls, Constructor<?> constructor, Enum<?>[] constructorArgs,
+                                List<FrameworkMethod> methods) throws InitializationError {
+    super(checkNotNull(cls, "cls"));
+    this.constructor = checkNotNull(constructor, "constructor");
+    this.constructorArgs = checkNotNull(constructorArgs, "constructorArgs");
+    this.methods = checkNotNull(methods, "methods");
+  }
+
+  @Override protected void validateConstructor(List<Throwable> errors) {
+    // Constructor was already validated by Burst.
+  }
+
+  @Override
+  protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation,
+                                                boolean isStatic, List<Throwable> errors) {
+    // Methods were already validated by Burst.
+  }
+
+  @Override
+  protected List<FrameworkMethod> getChildren() {
+    return methods;
+  }
+
+  @Override
+  protected String getName() {
+    return nameWithArguments(super.getName(), constructorArgs);
+  }
+
+  @Override
+  protected Description describeChild(FrameworkMethod method) {
+    return Description.createTestDescription(getName(), method.getName());
+  }
+
+
+  @Override
+  public Object createTest() throws Exception {
+    return constructor.newInstance(constructorArgs);
+  }
+
+  @Override
+  protected HelperTestRunner getHelperTestRunner(final Class bootstrappedTestClass) {
+    try {
+      return new HelperTestRunner(bootstrappedTestClass) {
+        @Override protected void validateConstructor(List<Throwable> errors) {
+          BurstRobolectricRunner.this.validateConstructor(errors);
+        }
+
+        @Override
+        protected void validatePublicVoidNoArgMethods(Class<? extends Annotation> annotation, boolean isStatic,
+            List<Throwable> errors) {
+          BurstRobolectricRunner.this.validatePublicVoidNoArgMethods(annotation, isStatic, errors);
+        }
+
+        @Override
+        protected Object createTest() throws Exception {
+          Constructor<?> parallelConstructor = bootstrappedTestClass.getConstructors()[0];
+          Enum[] parallelArgs = new Enum[parallelConstructor.getParameterTypes().length];
+          for (int i = 0; i < constructorArgs.length; i++) {
+            Class<? extends Enum> enumClass = (Class<? extends Enum>) parallelConstructor.getParameterTypes()[i];
+            String enumName = constructorArgs[i].name();
+            parallelArgs[i] = Enum.valueOf(enumClass, enumName);
+          }
+
+          return parallelConstructor.newInstance(parallelArgs);
+        }
+      };
+    } catch (InitializationError initializationError) {
+      throw new RuntimeException(initializationError);
+    }
+  }
+
+  @Override protected Statement methodBlock(final FrameworkMethod method) {
+    return new Statement() {
+      @Override
+      public void evaluate() throws Throwable {
+        BurstMethod burstMethod = (BurstMethod) method;
+        final Config config = getConfig(method.getMethod());
+        AndroidManifest appManifest = getAppManifest(config);
+        SdkEnvironment sdkEnvironment = getEnvironment(appManifest, config);
+        Thread.currentThread().setContextClassLoader(sdkEnvironment.getRobolectricClassLoader());
+
+        Class bootstrappedTestClass = sdkEnvironment.bootstrappedClass(getTestClass().getJavaClass());
+        HelperTestRunner helperTestRunner = getHelperTestRunner(bootstrappedTestClass);
+
+        Method bootstrappedMethod = null;
+        Method[] declaredMethods = bootstrappedTestClass.getDeclaredMethods();
+        for (Method declaredMethod : declaredMethods) {
+          if (declaredMethod.getName().equals(method.getMethod().getName()) &&
+              burstMethod.getMethodArgs().length == declaredMethod.getParameterTypes().length) {
+            bootstrappedMethod = declaredMethod;
+          }
+        }
+        if (bootstrappedMethod == null) {
+          throw new NoSuchMethodException(method.getMethod().getName());
+        }
+        Enum[] args = new Enum[burstMethod.getMethodArgs().length];
+        for (int i = 0; i < burstMethod.getMethodArgs().length; i++) {
+          Class<? extends Enum> enumClass = (Class<? extends Enum>) bootstrappedMethod.getParameterTypes()[i];
+          String enumName = burstMethod.getMethodArgs()[i].name();
+          args[i] = Enum.valueOf(enumClass, enumName);
+        };
+
+        configureShadows(sdkEnvironment, config);
+
+        ParallelUniverseInterface parallelUniverseInterface = getHooksInterface(sdkEnvironment);
+        try {
+          // Only invoke @BeforeClass once per class
+          if (!loadedTestClasses.contains(bootstrappedTestClass)) {
+            invokeBeforeClass(bootstrappedTestClass);
+          }
+          assureTestLifecycle(sdkEnvironment);
+
+          parallelUniverseInterface.resetStaticState();
+          parallelUniverseInterface.setSdkConfig(sdkEnvironment.getSdkConfig());
+
+          boolean strictI18n = determineI18nStrictState(bootstrappedMethod);
+
+          int sdkVersion = pickReportedSdkVersion(config, appManifest);
+          Class<?> versionClass = sdkEnvironment.bootstrappedClass(Build.VERSION.class);
+          staticField("SDK_INT").ofType(int.class).in(versionClass).set(sdkVersion);
+
+          ResourceLoader systemResourceLoader = sdkEnvironment.getSystemResourceLoader(MAVEN_CENTRAL, BurstRobolectricRunner.this);
+          setUpApplicationState(bootstrappedMethod, parallelUniverseInterface, strictI18n, systemResourceLoader, appManifest, config);
+          testLifecycle.beforeTest(bootstrappedMethod);
+        } catch (Exception e) {
+          e.printStackTrace();
+          throw new RuntimeException(e);
+        }
+
+        final Statement statement = helperTestRunner.methodBlock(new BurstMethod(bootstrappedMethod, args));
+
+        Map<Field, Object> withConstantAnnos = getWithConstantAnnotations(bootstrappedMethod);
+
+        // todo: this try/finally probably isn't right -- should mimic RunAfters? [xw]
+        try {
+          if (withConstantAnnos.isEmpty()) {
+            statement.evaluate();
+          } else {
+            synchronized (this) {
+              setupConstants(withConstantAnnos);
+              statement.evaluate();
+              setupConstants(withConstantAnnos);
+            }
+          }
+        } finally {
+          try {
+            parallelUniverseInterface.tearDownApplication();
+          } finally {
+            try {
+              internalAfterTest(bootstrappedMethod);
+            } finally {
+              parallelUniverseInterface.resetStaticState(); // afterward too, so stuff doesn't hold on to classes?
+              // todo: is this really needed?
+              Thread.currentThread().setContextClassLoader(RobolectricTestRunner.class.getClassLoader());
+            }
+          }
+        }
+      }
+    };
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/BurstRoboTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/BurstRoboTest.java
@@ -1,0 +1,181 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+
+import java.lang.reflect.Constructor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class BurstRoboTest {
+  private final RoboJournalingListener listener = new RoboJournalingListener();
+
+  enum First { APPLE, BEARD, COUCH }
+  enum Second { DINGO, EAGLE }
+
+  public static class One {
+    public One(First first) {}
+  }
+
+  public static class None {}
+  public static class Empty {
+    public Empty() {}
+  }
+  public static class NonPublic {
+    NonPublic() {}
+  }
+  public static class Multiple {
+    public Multiple(First first) {}
+    public Multiple(Second second) {}
+  }
+
+  @Test public void noConstructor() {
+    Constructor<?> constructor = BurstJUnit4.findConstructor(None.class);
+    assertThat(constructor).isNotNull();
+    assertThat(constructor.getParameterTypes()).isEmpty();
+  }
+
+  @Test public void nonPublicConstructor() {
+    try {
+      BurstJUnit4.findConstructor(NonPublic.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage(
+          NonPublic.class.getName() + " requires a single public constructor.");
+    }
+  }
+
+  @Test public void singleConstructor() {
+    Constructor<?> constructor = BurstJUnit4.findConstructor(One.class);
+    assertThat(constructor).isNotNull();
+    assertThat(constructor.getParameterTypes()).containsExactly(First.class);
+  }
+
+  @Test public void multipleConstructors() {
+    try {
+      BurstJUnit4.findConstructor(Multiple.class);
+      fail();
+    } catch (IllegalStateException e) {
+      assertThat(e).hasMessage(Multiple.class.getName() + " requires a single public constructor.");
+    }
+  }
+
+  @Test public void constructorNone() throws InitializationError {
+    BurstRobolectric runner = new BurstRobolectric(RoboConstructorNoArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.RoboConstructorNoArgumentTest)",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorNoArgumentTest)");
+  }
+
+  @Test public void constructorSingle() throws InitializationError {
+    BurstRobolectric runner = new BurstRobolectric(RoboConstructorSingleArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.PEPSI])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.PEPSI])",
+        "START testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.COKE])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.COKE])",
+        "START testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.RC_COLA])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorSingleArgumentTest[RoboSoda.RC_COLA])");
+  }
+
+  @Test public void constructorMultiple() throws InitializationError {
+    BurstRobolectric runner = new BurstRobolectric(RoboConstructorMultipleArgumentTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.CHIPS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.NUTS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.PEPSI, RoboSnack.CANDY])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.CHIPS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.NUTS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.COKE, RoboSnack.CANDY])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.CHIPS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.CHIPS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.NUTS])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.NUTS])",
+        "START testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.CANDY])",
+        "FINISH testMethod(com.squareup.burst.RoboConstructorMultipleArgumentTest[RoboSoda.RC_COLA, RoboSnack.CANDY])");
+  }
+
+  @Test public void method() throws InitializationError {
+    BurstRobolectric runner = new BurstRobolectric(RoboMethodTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START single[RoboSoda.PEPSI](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.PEPSI](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.COKE](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.COKE](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.RC_COLA](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.RC_COLA](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.PEPSI, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.PEPSI, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.PEPSI, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.PEPSI, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.PEPSI, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.PEPSI, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.COKE, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.COKE, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.COKE, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.COKE, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.COKE, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.COKE, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.RC_COLA, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.RC_COLA, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.RC_COLA, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.RC_COLA, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START single[RoboSoda.RC_COLA, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH single[RoboSoda.RC_COLA, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "START none(com.squareup.burst.RoboMethodTest)",
+        "FINISH none(com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.PEPSI, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.PEPSI, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.PEPSI, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.PEPSI, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.PEPSI, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.PEPSI, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.COKE, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.COKE, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.COKE, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.COKE, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.COKE, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.COKE, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.RC_COLA, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.RC_COLA, RoboSnack.CHIPS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.RC_COLA, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.RC_COLA, RoboSnack.NUTS](com.squareup.burst.RoboMethodTest)",
+        "START multiple[RoboSoda.RC_COLA, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)",
+        "FINISH multiple[RoboSoda.RC_COLA, RoboSnack.CANDY](com.squareup.burst.RoboMethodTest)");
+  }
+
+  @Test public void constructorAndMethod() throws InitializationError {
+    BurstRobolectric runner = new BurstRobolectric(RoboConstructorAndMethodTest.class);
+    runner.run(listener.notifier());
+    assertThat(listener.journal()).containsExactly(
+        "START testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "FINISH testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "START testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "FINISH testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "START testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "FINISH testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.PEPSI])",
+        "START testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "FINISH testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "START testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "FINISH testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "START testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "FINISH testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.COKE])",
+        "START testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])",
+        "FINISH testMethod[RoboSnack.CHIPS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])",
+        "START testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])",
+        "FINISH testMethod[RoboSnack.NUTS](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])",
+        "START testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])",
+        "FINISH testMethod[RoboSnack.CANDY](com.squareup.burst.RoboConstructorAndMethodTest[RoboSoda.RC_COLA])");
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboActivityTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboActivityTest.java
@@ -21,7 +21,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(BurstRobolectric.class)
 @Config(manifest = "./burst-android-test/app/AndroidManifest.xml", emulateSdk = 18)
-public class RoboActivityTest {
+final public class RoboActivityTest {
   private final RoboSoda soda;
 
   public RoboActivityTest(RoboSoda soda) {
@@ -32,9 +32,7 @@ public class RoboActivityTest {
     assertTrue(true);
   }
 
-
-  @Test
-  public void testDrinkIsDisplayed() {
+  @Test public void testDrinkIsDisplayed() {
     Activity activity = Robolectric.buildActivity(RootActivity.class).create().get();
     View decorView = activity.getWindow().getDecorView();
     ArrayList<View> viewsWithMatchingDrinkName = new ArrayList<>();

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboActivityTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboActivityTest.java
@@ -1,0 +1,44 @@
+package com.squareup.burst;
+
+import android.app.Activity;
+import android.test.ActivityInstrumentationTestCase2;
+import android.view.View;
+import com.example.burst.RootActivity;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+
+import static android.view.View.FIND_VIEWS_WITH_TEXT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Launches {@link com.example.burst.RootActivity} and interacts with some views therein.
+ */
+@RunWith(BurstRobolectric.class)
+@Config(manifest = "./burst-android-test/app/AndroidManifest.xml", emulateSdk = 18)
+public class RoboActivityTest {
+  private final RoboSoda soda;
+
+  public RoboActivityTest(RoboSoda soda) {
+    this.soda = soda;
+  }
+
+  @Test public void none() {
+    assertTrue(true);
+  }
+
+
+  @Test
+  public void testDrinkIsDisplayed() {
+    Activity activity = Robolectric.buildActivity(RootActivity.class).create().get();
+    View decorView = activity.getWindow().getDecorView();
+    ArrayList<View> viewsWithMatchingDrinkName = new ArrayList<>();
+    decorView.findViewsWithText(viewsWithMatchingDrinkName, soda.name(), FIND_VIEWS_WITH_TEXT);
+    assertEquals(1, viewsWithMatchingDrinkName.size());
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorAndMethodTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorAndMethodTest.java
@@ -1,0 +1,20 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstRobolectric.class)
+public final class RoboConstructorAndMethodTest {
+  private final RoboSoda soda;
+
+  public RoboConstructorAndMethodTest(RoboSoda soda) {
+    this.soda = soda;
+  }
+
+  @Test public void testMethod(RoboSnack snack) {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorMultipleArgumentTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorMultipleArgumentTest.java
@@ -1,0 +1,22 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstRobolectric.class)
+public final class RoboConstructorMultipleArgumentTest {
+  private final RoboSoda soda;
+  private final RoboSnack snack;
+
+  public RoboConstructorMultipleArgumentTest(RoboSoda soda, RoboSnack snack) {
+    this.soda = soda;
+    this.snack = snack;
+  }
+
+  @Test public void testMethod() {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorNoArgumentTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorNoArgumentTest.java
@@ -1,0 +1,13 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstRobolectric.class)
+public final class RoboConstructorNoArgumentTest {
+  @Test public void testMethod() {
+    assertTrue(true);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorSingleArgumentTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboConstructorSingleArgumentTest.java
@@ -1,0 +1,19 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(BurstRobolectric.class)
+public final class RoboConstructorSingleArgumentTest {
+  private final RoboSoda soda;
+
+  public RoboConstructorSingleArgumentTest(RoboSoda soda) {
+    this.soda = soda;
+  }
+
+  @Test public void testMethod() {
+    assertNotNull(soda);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboJournalingListener.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboJournalingListener.java
@@ -1,0 +1,59 @@
+package com.squareup.burst;
+
+import org.junit.runner.Description;
+import org.junit.runner.Result;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
+import org.junit.runner.notification.RunNotifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+final class RoboJournalingListener {
+  private final RunNotifier notifier = new RunNotifier();
+  private final List<String> journal = new ArrayList<>();
+
+  RoboJournalingListener() {
+    notifier.addListener(new RunListener() {
+      @Override public void testRunStarted(Description description) throws Exception {
+        throw new AssertionError();
+      }
+
+      @Override public void testRunFinished(Result result) throws Exception {
+        throw new AssertionError();
+      }
+
+      @Override public void testStarted(Description description) throws Exception {
+        journal.add("START " + description.getDisplayName());
+      }
+
+      @Override public void testFinished(Description description) throws Exception {
+        journal.add("FINISH " + description.getDisplayName());
+      }
+
+      @Override public void testFailure(Failure failure) throws Exception {
+        journal.add(
+            "FAIL " + failure.getDescription().getDisplayName() + " " + failure.getMessage());
+      }
+
+      @Override public void testAssumptionFailure(Failure failure) {
+        journal.add("ASSUMPTION FAIL "
+            + failure.getDescription().getDisplayName()
+            + " "
+            + failure.getMessage());
+      }
+
+      @Override public void testIgnored(Description description) throws Exception {
+        journal.add("IGNORE " + description.getDisplayName());
+      }
+    });
+  }
+
+  RunNotifier notifier() {
+    return notifier;
+  }
+
+  List<String> journal() {
+    return new ArrayList<>(journal);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboMethodTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboMethodTest.java
@@ -22,7 +22,7 @@ public final class RoboMethodTest {
     assertNotNull(soda);
   }
 
-  // tests that the correct method is called when two have the same name but different signatures
+  // Verifies the correct method is called when the name is the same but the parameters vary.
   @Test public void single(RoboSoda soda, RoboSnack snack) {
     assertNotNull(soda);
     assertNotNull(snack);

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboMethodTest.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboMethodTest.java
@@ -1,0 +1,35 @@
+package com.squareup.burst;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstRobolectric.class)
+@Config(manifest=Config.NONE)
+public final class RoboMethodTest {
+  public RoboMethodTest() { }
+
+  @Test public void none() {
+    assertTrue(true);
+  }
+
+  @Test public void single(RoboSoda soda) {
+    assertNotNull(soda);
+  }
+
+  // tests that the correct method is called when two have the same name but different signatures
+  @Test public void single(RoboSoda soda, RoboSnack snack) {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+
+  @Test public void multiple(RoboSoda soda, RoboSnack snack) {
+    assertNotNull(soda);
+    assertNotNull(snack);
+  }
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboSnack.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboSnack.java
@@ -1,0 +1,5 @@
+package com.squareup.burst;
+
+public enum RoboSnack {
+  CHIPS, NUTS, CANDY
+}

--- a/burst-robolectric/src/test/java/com/squareup/burst/RoboSoda.java
+++ b/burst-robolectric/src/test/java/com/squareup/burst/RoboSoda.java
@@ -1,0 +1,5 @@
+package com.squareup.burst;
+
+public enum RoboSoda {
+  PEPSI, COKE, RC_COLA;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,6 @@
 
     <robolectric.version>2.3</robolectric.version>
     <festreflect.version>1.4.1</festreflect.version>
-    <mavenanttasks.version>2.1.3</mavenanttasks.version>
   </properties>
 
   <scm>
@@ -95,11 +94,6 @@
         <groupId>org.easytesting</groupId>
         <artifactId>fest-reflect</artifactId>
         <version>${festreflect.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.maven</groupId>
-        <artifactId>maven-ant-tasks</artifactId>
-        <version>${mavenanttasks.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,10 @@
 
     <assertj.version>1.6.1</assertj.version>
     <dexmaker.version>1.1</dexmaker.version>
+
+    <robolectric.version>2.3</robolectric.version>
+    <festreflect.version>1.4.1</festreflect.version>
+    <mavenanttasks.version>2.1.3</mavenanttasks.version>
   </properties>
 
   <scm>
@@ -81,6 +85,21 @@
         <groupId>com.google.dexmaker</groupId>
         <artifactId>dexmaker</artifactId>
         <version>${dexmaker.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.robolectric</groupId>
+        <artifactId>robolectric</artifactId>
+        <version>${robolectric.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.easytesting</groupId>
+        <artifactId>fest-reflect</artifactId>
+        <version>${festreflect.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.maven</groupId>
+        <artifactId>maven-ant-tasks</artifactId>
+        <version>${mavenanttasks.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <module>burst-android</module>
     <module>burst-android-test</module>
     <module>burst-junit4</module>
+    <module>burst-robolectric</module>
   </modules>
 
   <properties>


### PR DESCRIPTION
This branch pulls up all the private logic from RobolectricTestRunner into BurstRobolectricRunner.  Unfortunately, it's only compatible with Robolectric 2.3 right now, but with some minor changes to Robolectric (next major version) we could easily remove most of the logic from BurstRobolectricRunner.