### PR TITLE
Handling #getFilteredChildren incompatibility in new junit

### DIFF
--- a/burst-junit4/src/main/java/com/squareup/burst/ParentRunnerSpy.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/ParentRunnerSpy.java
@@ -2,6 +2,8 @@ package com.squareup.burst;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import org.junit.runners.ParentRunner;
 
@@ -27,7 +29,7 @@ final class ParentRunnerSpy {
   static <T> List<T> getFilteredChildren(ParentRunner<T> parentRunner) {
     try {
       //noinspection unchecked
-      return (List<T>) getFilteredChildrenMethod.invoke(parentRunner);
+      return new ArrayList<>((Collection<T>) getFilteredChildrenMethod.invoke(parentRunner));
     } catch (IllegalAccessException | InvocationTargetException e) {
       throw new RuntimeException("Failed to invoke getFilteredChildren()", e);
     }

--- a/burst-junit4/src/test/java/com/squareup/burst/ParentRunnerSpyTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ParentRunnerSpyTest.java
@@ -1,0 +1,34 @@
+package com.squareup.burst;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runners.ParentRunner;
+
+import static org.junit.Assert.assertEquals;
+
+public class ParentRunnerSpyTest {
+
+  @Test
+  public void testGetFilteredChildren() throws Exception {
+    List<String> children =
+        ParentRunnerSpy.getFilteredChildren(new ParentRunner<String>(ParentRunnerSpyTest.class) {
+          @Override protected List<String> getChildren() {
+            ArrayList<String> children = new ArrayList<>();
+            children.add("children");
+            return children;
+          }
+
+          @Override protected Description describeChild(String o) {
+            return null;
+          }
+
+          @Override protected void runChild(String o, RunNotifier runNotifier) {}
+        });
+
+    assertEquals(1, children.size());
+    assertEquals("children", children.get(0));
+  }
+}


### PR DESCRIPTION
`ParentRunner` on JUnit master (link https://github.com/junit-team/junit/blob/master/src/main/java/org/junit/runners/ParentRunner.java#L422) changed its signature for `getFilteredChildren` from a `List` to a `Collection`. Ran into this attempting to integrate burst into some Square code, and I'm assuming our version of junit there overrides the pinned version of junit used here, 4.11. 

This change should be safe for current JUnit version and future JUnit versions (newest is 4.12).

@dlubarov @JakeWharton 