### PR TITLE
Stop allowing extra default constructors

### DIFF
--- a/burst/src/main/java/com/squareup/burst/BurstableConstructor.java
+++ b/burst/src/main/java/com/squareup/burst/BurstableConstructor.java
@@ -25,11 +25,10 @@ final class BurstableConstructor {
     } else if (constructors.length == 1) {
       return constructors[0];
     } else {
-      return singleParameterizedConstructorOrThrow(constructors,
-          "Class "
-              + cls.getName()
-              + " has too many parameterized constructors. "
-              + "Should only be 1 (with enum variations).");
+      throw new IllegalStateException("Class "
+          + cls.getName()
+          + " has too many parameterized constructors. "
+          + "Should only be 1 (with enum variations).");
     }
   }
 
@@ -56,34 +55,6 @@ final class BurstableConstructor {
     }
 
     return filteredConstructors.toArray(new TestConstructor[filteredConstructors.size()]);
-  }
-
-  /**
-   * Finds the constructor that has parameters.
-   * Assumes at least one non-default constructor is present.
-   * E.g. Given [Ctor(), Ctor(Object)], returns Ctor(Object).
-   *
-   * @throws IllegalStateException if more than one constructor has parameters
-   */
-  private static TestConstructor singleParameterizedConstructorOrThrow(
-      final TestConstructor[] constructors, final String message) {
-    TestConstructor parameterizedConstructor = null;
-
-    for (TestConstructor constructor : constructors) {
-      if (constructor.getVariationTypes().length > 0) {
-        if (null == parameterizedConstructor) {
-          parameterizedConstructor = constructor;
-        } else {
-          throw new IllegalStateException(message);
-        }
-      }
-    }
-
-    if (null == parameterizedConstructor) {
-      throw new IllegalArgumentException("Must pass at least one parameterized constructor");
-    }
-
-    return parameterizedConstructor;
   }
 
   /**

--- a/burst/src/test/java/com/squareup/burst/BurstableConstructorTest.java
+++ b/burst/src/test/java/com/squareup/burst/BurstableConstructorTest.java
@@ -41,8 +41,10 @@ public class BurstableConstructorTest {
     public DefaultAndOne(First first) {}
   }
   @Test public void defaultAndParameterizedConstructor() {
-    TestConstructor ctor = BurstableConstructor.findSingle(DefaultAndOne.class);
-    assertThat(ctor.getVariationTypes()).containsExactly(First.class);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("too many parameterized constructors");
+
+    BurstableConstructor.findSingle(DefaultAndOne.class);
   }
 
   public static class NonPublicConstructor {


### PR DESCRIPTION
Now that we've dropped Android support there's no need for an extra default constructor; all Burst tests should have one constructor.

It's possible this could break existing tests, but it's unavoidable unless we keep this leniency forever.