### PR TITLE
Don't invoke BeforeClass/AfterClass/ClassRule for each variation

### DIFF
--- a/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
@@ -2,13 +2,16 @@ package com.squareup.burst;
 
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runner.manipulation.Filter;
 import org.junit.runner.manipulation.NoTestsRemainException;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
 
 import static com.squareup.burst.BurstJUnit4.nameWithArguments;
 import static com.squareup.burst.Util.checkNotNull;
@@ -43,6 +46,24 @@ final class BurstRunner extends BlockJUnit4ClassRunner {
 
   @Override protected Object createTest() throws Exception {
     return constructor.newInstance(constructorArgs);
+  }
+
+  @Override protected Statement withBeforeClasses(Statement statement) {
+    // The parent runner, BurstJUnit4, will handle @BeforeClass/@AfterClass/@ClassRule once for the
+    // whole class. We don't want to repeat them for each variation.
+    return statement;
+  }
+
+  @Override protected Statement withAfterClasses(Statement statement) {
+    // The parent runner, BurstJUnit4, will handle @BeforeClass/@AfterClass/@ClassRule once for the
+    // whole class. We don't want to repeat them for each variation.
+    return statement;
+  }
+
+  @Override protected List<TestRule> classRules() {
+    // The parent runner, BurstJUnit4, will handle @BeforeClass/@AfterClass/@ClassRule once for the
+    // whole class. We don't want to repeat them for each variation.
+    return Collections.emptyList();
   }
 
   @Override protected void validateConstructor(List<Throwable> errors) {

--- a/burst-junit4/src/test/java/com/squareup/burst/BeforeAndAfterClassTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/BeforeAndAfterClassTest.java
@@ -1,0 +1,39 @@
+package com.squareup.burst;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstJUnit4.class)
+public class BeforeAndAfterClassTest {
+  private static boolean beforeClassCalled = false;
+  private static boolean afterClassCalled = false;
+
+  private final Snack snack;
+
+  public BeforeAndAfterClassTest(Snack snack) {
+    this.snack = snack;
+  }
+
+  @BeforeClass public static void beforeClass() {
+    assertFalse(beforeClassCalled);
+    beforeClassCalled = true;
+  }
+
+  @AfterClass public static void afterClass() {
+    assertTrue(beforeClassCalled);
+    assertFalse(afterClassCalled);
+    afterClassCalled = true;
+  }
+
+  @Test public void testSnackIsSet() {
+    assertTrue(beforeClassCalled);
+    assertFalse(afterClassCalled);
+    assertNotNull(snack);
+  }
+}

--- a/burst-junit4/src/test/java/com/squareup/burst/ClassRuleTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/ClassRuleTest.java
@@ -1,0 +1,42 @@
+package com.squareup.burst;
+
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstJUnit4.class)
+public class ClassRuleTest {
+  @ClassRule public static TestRule rule = new ExternalResource() {
+    @Override protected void before() throws Throwable {
+      assertFalse(beforeCalled);
+      beforeCalled = true;
+    }
+
+    @Override protected void after() {
+      assertTrue(beforeCalled);
+      assertFalse(afterCalled);
+      afterCalled = true;
+    }
+  };
+
+  private static boolean beforeCalled = false;
+  private static boolean afterCalled = false;
+
+  private final Snack snack;
+
+  public ClassRuleTest(Snack snack) {
+    this.snack = snack;
+  }
+
+  @Test public void testSnackIsSet() {
+    assertTrue(beforeCalled);
+    assertFalse(afterCalled);
+    assertNotNull(snack);
+  }
+}


### PR DESCRIPTION
`BurstJUnit4` already invokes them once for the whole class, so the `BurstRunner`s should just no-op.

Fixes #52.