### PR TITLE
Pass annotations for description.getAnnotations()

### DIFF
--- a/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
+++ b/burst-junit4/src/main/java/com/squareup/burst/BurstRunner.java
@@ -41,7 +41,7 @@ final class BurstRunner extends BlockJUnit4ClassRunner {
   }
 
   @Override protected Description describeChild(FrameworkMethod method) {
-    return Description.createTestDescription(getName(), method.getName());
+    return Description.createTestDescription(getName(), method.getName(), method.getAnnotations());
   }
 
   @Override protected Object createTest() throws Exception {
@@ -104,6 +104,6 @@ final class BurstRunner extends BlockJUnit4ClassRunner {
    */
   private Description describeChildPlain(FrameworkMethod method) {
     return Description.createTestDescription(getTestClass().getJavaClass(),
-        method.getMethod().getName());
+        method.getMethod().getName(), method.getAnnotations());
   }
 }

--- a/burst-junit4/src/test/java/com/squareup/burst/RuleUsingAnnotationsTest.java
+++ b/burst-junit4/src/test/java/com/squareup/burst/RuleUsingAnnotationsTest.java
@@ -1,0 +1,58 @@
+package com.squareup.burst;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+import org.junit.runner.RunWith;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(BurstJUnit4.class)
+public class RuleUsingAnnotationsTest {
+
+  @Target(METHOD)
+  @Retention(RUNTIME) @interface CustomAnnotation {
+
+  }
+
+  static class RuleWithAnnotation extends TestWatcher {
+
+    Collection<Annotation> annotations;
+
+    @Override
+    protected void starting(Description description) {
+      annotations = description.getAnnotations();
+    }
+  }
+
+  @Rule
+  public RuleWithAnnotation rule = new RuleWithAnnotation();
+
+  @Test
+  @CustomAnnotation
+  public void shouldDetectAnnotationsOnATest() {
+    assertEquals(2, rule.annotations.size());
+
+    boolean junitTestAnnotationDetected = false;
+    boolean customAnnotationDetected = false;
+
+    for (Annotation annotation : rule.annotations) {
+      if (annotation.annotationType() == Test.class) {
+        junitTestAnnotationDetected = true;
+      } else if (annotation.annotationType() == CustomAnnotation.class) {
+        customAnnotationDetected = true;
+      }
+    }
+
+    assertTrue(junitTestAnnotationDetected);
+    assertTrue(customAnnotationDetected);
+  }
+}


### PR DESCRIPTION
Initially I thought it was [a Kotlin problem](https://youtrack.jetbrains.com/issue/KT-12557), but turned out Burst doesn't pass test method annotations to `Description`, fixed that.